### PR TITLE
Replace OCP\ILogger with Psr\Log\LoggerInterface

### DIFF
--- a/lib/Controller/DiscourseController.php
+++ b/lib/Controller/DiscourseController.php
@@ -9,9 +9,9 @@ use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Controller;
 use OCP\IUserManager;
 use OCP\IGroupManager;
-use OCP\ILogger;
 use OCP\IUserSession;
 use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 use Cviebrock\DiscoursePHP\SSOHelper;
 
 class DiscourseController extends Controller {
@@ -23,7 +23,7 @@ class DiscourseController extends Controller {
     private $groupManager;
     private $urlGenerator;
 
-    public function __construct($AppName, IRequest $request, IConfig $config, IUserManager $userManager,IGroupManager $groupManager, ILogger $logger, IUserSession $userSession, IURLGenerator $urlGenerator, $UserId){
+    public function __construct($AppName, IRequest $request, IConfig $config, IUserManager $userManager,IGroupManager $groupManager, LoggerInterface $logger, IUserSession $userSession, IURLGenerator $urlGenerator, $UserId){
             parent::__construct($AppName, $request);
             $this->userId = $UserId;
             $this->config = $config;


### PR DESCRIPTION
OCP\ILogger was removed in Nextcloud version 31.0.0, see: https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_31.html#id4